### PR TITLE
Update workflow to use artifact actions v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,6 @@ jobs:
         with:
           command_string: 'validate threshold -i results.json -F threshold.yml'
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: results.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: macos-13
     name: Validate profile
     env:
       CHEF_LICENSE: accept-silent


### PR DESCRIPTION
Changes made
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.
- Updated from macos-12 to macos-13 since the former results in the test.yml workflow to auto-cancel/fail itself 